### PR TITLE
Fixed column name collision on stories table

### DIFF
--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -4,7 +4,7 @@ class Story < ActiveRecord::Base
                   :planner,
                   :url,
                   :status,
-                  :type,
+                  :story_type,
                   :story_id,
                   :points
 
@@ -26,12 +26,12 @@ private
   end
 
   def self.build_story(story)
-    create( requester: story.requested_by,
-            message:   story.name,
-            type:      story.story_type,
-            points:    story.estimate,
-            story_id:  story.id,
-            status:    story.current_state,
-            url:       story.url )
+    create( requester:  story.requested_by,
+            message:    story.name,
+            story_type: story.story_type,
+            points:     story.estimate,
+            story_id:   story.id,
+            status:     story.current_state,
+            url:        story.url )
   end
 end

--- a/db/migrate/20130519175022_change_type_column_in_stories_table.rb
+++ b/db/migrate/20130519175022_change_type_column_in_stories_table.rb
@@ -1,0 +1,5 @@
+class ChangeTypeColumnInStoriesTable < ActiveRecord::Migration
+  def change
+    rename_column :stories, :type, :story_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130519002259) do
+ActiveRecord::Schema.define(:version => 20130519175022) do
 
   create_table "authors", :force => true do |t|
     t.string   "login"
@@ -71,7 +71,7 @@ ActiveRecord::Schema.define(:version => 20130519002259) do
     t.integer  "planner_id"
     t.string   "url"
     t.string   "status"
-    t.string   "type"
+    t.string   "story_type"
     t.integer  "points",     :default => 0
     t.integer  "story_id"
   end


### PR DESCRIPTION
Renamed the column 'type' in the 'stories' table to 'story_type' due to name collision problems.
